### PR TITLE
feat: Implement GitHub Sponsor Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,19 +12,26 @@
     <link rel="stylesheet" href="./styles/styles.css">
 </head>
 <body>
-    
+    <section class="gh-sponsors">
+        <!-- 
+       * Embed a GitHub Sponsors card within the section.
+       * The 'iframe' element fetches and displays the sponsorship card from the specified URL.
+   -->
+       <iframe src="https://github.com/sponsors/samucodesh/card" title="Sponsor samucodesh" height="180" width="100%" style="border: 0;"></iframe>
+   </section>
+
     <section class="gcalendar">
         <!-- Google Calendar Appointment Scheduling begin -->
         <iframe src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ3nRiaquDIEA6XlGCoRJP9TnOD6ssn-2oY3TEk2EPJ0oKvBGIQtKFxibpj8bbAiOaXGFm9Q-J9X?gv=true" style="border: 0" width="100%" height="600" frameborder="0"></iframe>
         <!-- end Google Calendar Appointment Scheduling -->
     </section>
+    
     <nav>
          <!-- 
         * Create a nav with links to various contact methods. 
         * Each <a> element represents a clickable link.
     -->
         <a href="mailto:ssotohoyos2000@gmail.com" target="_blank">Send email</a>
-        <a href="https://github.com/samucodesh" target="_blank">Github</a>
         <a href="https://platzi.com/p/SamuelSH/" target="_blank">Platzi</a>
         <a href="https://www.linkedin.com/in/samuel-soto-hoyos-656316215" target="_blank">Linkedin</a>
         <a href="https://twitter.com/samucodesh" target="_blank">Twitter</a>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -17,6 +17,14 @@ html {
     }
 }
 
+/* 
+Styles the GitHub Sponsors section to center text and use the large font size 
+*/
+.gh-sponsors {
+    text-align: center;
+    font-size: var(--lg);
+}
+
 /*
 * Style elements with the class 'gcalendar'.
 * Sets font size to the value of the --sm variable (small). 


### PR DESCRIPTION
## Description

This pull request addresses [issue #20](https://github.com/samucodesh/samucodesh.github.io/issues/20), which implements a dedicated GitHub Sponsor section on the website. This section serves as an "About Me" area, showcasing the website owner/developer and providing links to both the GitHub profile and a GitHub Sponsor page.

### Key Changes:

*   **HTML:** Added the GitHub Sponsor section as an iframe to display "About Me" and sponsorship information. The separate link to my GitHub profile was removed because its already included in the iframe content.
*   **CSS:** CSS rules are added to gh-sponsor class.

## Related Tickets & Documents

Closes #20 